### PR TITLE
Use PEP518 compliant pyproject format

### DIFF
--- a/coverage_threshold/cli/read_config.py
+++ b/coverage_threshold/cli/read_config.py
@@ -9,11 +9,16 @@ from coverage_threshold.model.config import Config
 def read_config(config_file_name: Optional[str]) -> Config:
     DEFAULT_FILENAME = "./pyproject.toml"
     if config_file_name is not None:
-        return Config.parse(toml.load(config_file_name)["coverage-threshold"])
+        if not os.path.isfile(config_file_name):
+            raise FileNotFoundError(f"Config file {config_file_name} not found")
     else:
-        if os.path.isfile(DEFAULT_FILENAME):
-            return Config.parse(
-                toml.load(DEFAULT_FILENAME).get("coverage-threshold", {})
-            )
-        else:
-            return Config()
+        config_file_name = DEFAULT_FILENAME
+    if os.path.isfile(config_file_name):
+        try:
+            # PEP 518 compliant version
+            return Config.parse(toml.load(config_file_name)["tool"]["coverage-threshold"])
+        except KeyError:
+            # Legacy version
+            return Config.parse(toml.load(config_file_name).get("coverage-threshold", {}))
+    else:
+        return Config()


### PR DESCRIPTION
Parameters should be under the [tool.coverage-threshold] key:
https://peps.python.org/pep-0518/#tool-table.
If not found, fall back to (legacy) [coverage-threshold].

Note: current key fails tools validating [pyproject.toml's schema](https://peps.python.org/pep-0518/#json-schema)